### PR TITLE
add longest-common-prefix autocompletion for documents

### DIFF
--- a/longest-common-prefix.js
+++ b/longest-common-prefix.js
@@ -1,0 +1,20 @@
+'use strict';
+
+// find the longest common prefix in a list of strings
+module.exports = function longestCommonPrefix(strings) {
+  if (!strings.length) {
+    return '';
+  }
+
+  var candidate = strings[0];
+  for (var i = 1; i < strings.length; i++) {
+    var str = strings[i];
+    while (str.indexOf(candidate) !== 0 && candidate) {
+      candidate = candidate.substring(0, candidate.length -1);
+    }
+    if (!candidate) {
+      break;
+    }
+  }
+  return candidate;
+};

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A shell to interact with CouchDB as if it were a file system",
   "dependencies": {
     "cloudant": "^1.0.0-beta3",
+    "nano": "^6.1.2",
     "shell": "^0.3.2"
   },
   "repository": "https://github.com/glynnbird/couchshell.git",
@@ -16,6 +17,6 @@
   "author": "Glynn Bird",
   "license": "BSD",
   "bin": {
-      "couchshell": "app.js"
+    "couchshell": "app.js"
   }
 }


### PR DESCRIPTION
This allows the CLI to correctly autocomplete document names.
E.g. if you have docs "foobar" and "foobaz" and you type "foo"
then hit TAB, it will autocomplete "foo". Subsequent TAB presses
will show the list "foobar", "foobaz".
